### PR TITLE
Dropshadow Fix on Smaller Screens

### DIFF
--- a/src/components/council/comms/CommDialogButton.jsx
+++ b/src/components/council/comms/CommDialogButton.jsx
@@ -25,7 +25,7 @@ export const CommDialogButton = ({ role, description, names }) => {
           width: theme.spacing(40),
           justifyContent: "space-between",
           textTransform: "uppercase",
-          boxShadow: {xs: theme.shadows[1], sm: theme.shadows},
+          boxShadow: theme.shadows[3],
           color: theme.palette.text.primary,
           background: "#fff",
           padding: theme.spacing(1, 1, 1, 3),

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -1,10 +1,6 @@
 // Package Imports
 import React from "react";
-import {
-  Paper,
-  Typography,
-  useTheme,
-} from "@mui/material";
+import { Paper, Typography, useTheme } from "@mui/material";
 
 export const EventCard = ({ icon, eventName }) => {
   const theme = useTheme();
@@ -17,7 +13,7 @@ export const EventCard = ({ icon, eventName }) => {
         minWidth: theme.spacing(34),
         padding: theme.spacing(5, 4),
         textAlign: "center",
-        boxShadow: {xs: theme.shadows[1], sm: theme.shadows},
+        boxShadow: theme.shadows[3],
       }}
     >
       {icon}


### PR DESCRIPTION
Fixes issue #17. Issue is with MUI breakpoints. 

CommDialogButton.jsx uses theme.shadows
https://github.com/zoouofc/new-website/blob/5229773a3bc27a133c9358829778a1e2ba143a97/src/components/council/comms/CommDialogButton.jsx#L20-L33

theme.shadows is an array with `"none"` as the first item, this occurs at 0px-600px and thus disappears on smaller screens.
https://github.com/zoouofc/new-website/blob/5229773a3bc27a133c9358829778a1e2ba143a97/src/components/Theme.jsx#L85-L89

Fix is to override breakpoint at xs (0px-600px by default)
`boxShadow: {xs: theme.shadows[1], sm: theme.shadows},`